### PR TITLE
fix: do not write na in aggregated metrics

### DIFF
--- a/src/aidial_rag_eval/evaluate.py
+++ b/src/aidial_rag_eval/evaluate.py
@@ -85,6 +85,7 @@ def evaluate(
     )
     aggregated_metrics = df_final.mean(numeric_only=True)
     assert isinstance(aggregated_metrics, pd.Series)
+    aggregated_metrics.dropna(inplace=True)
 
     metrics = Dataset.write_dataframe(
         df_final,


### PR DESCRIPTION
### Description of changes

- Do not write metrics with NA values in aggregated metrics. Rag eval UI does not understand NA, so it is better to skip these values.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
