### PR TITLE
chore: specify poetry version in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,4 +14,5 @@ jobs:
     secrets: inherit
     with:
       python-version: 3.11
+      poetry-version: 2.2.1
       code-checks-python-versions: '["3.11", "3.12", "3.13", "3.14"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,5 @@ jobs:
     secrets: inherit
     with:
       python-version: 3.11
+      poetry-version: 2.2.1
       code-checks-python-versions: '["3.11", "3.12", "3.13", "3.14"]'


### PR DESCRIPTION
### Description of changes

Explicitly specify poetry version in CI scripts to fix errors with ai-dial-ci 3.1.3: https://github.com/epam/ai-dial-rag-eval/actions/runs/22662804484/job/65748434161?pr=73#step:4:27

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
