### PR TITLE
fix: pandas mean and median

### DIFF
--- a/src/aidial_rag_eval/dataframe/metrics.py
+++ b/src/aidial_rag_eval/dataframe/metrics.py
@@ -165,9 +165,9 @@ def calculate_generation_metrics(
     ]
     if nli_columns:
         sub_df_nli = df_metrics[nli_columns]
-        df_metrics["mean_" + inference_column] = sub_df_nli.mean(1)
+        df_metrics["mean_" + inference_column] = sub_df_nli.mean(1, skipna=False)
         df_metrics["median_" + inference_column] = sub_df_nli.median(
-            1
+            1, skipna=False
         )  # pyright: ignore # noqa
 
     return df_metrics


### PR DESCRIPTION
### Applicable issues

- After the update with error handling, our inference rows ( ctx_ans_inference, gt_ans_inference, and ans_gt_inference) may contain NaN values. The metrics mean_inference and median_inference are calculated over them. With the default behavior of pd.DataFrame, the mean is computed while skipping NaN values, which leads to: 1) a non-representative number for comparison 2) the error information in the row may be overlooked by the user if they only check the mean value.

### Checklist

- in pd.DataFrame, when calling mean, by default it computes the average only over non-NaN values; now, if there is at least one NaN, the result will also be NaN. 

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
