### PR TITLE
ci: re-use venv

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -88,3 +88,6 @@ resolutions:
     - message: ".*PyPI::annotated-doc:0\\.0\\.4.*"
       reason: "CANT_FIX_EXCEPTION"
       comment: "MIT License: https://github.com/fastapi/annotated-doc/blob/0.0.4/LICENSE"
+    - message: ".*PyPI::websockets:16.*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/python-websockets/websockets/blob/16.x/LICENSE"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,3 @@
 # Vulnerability in langchain load_prompt and load_prompt_from_config: https://github.com/advisories/GHSA-qh6h-p6c9-ff54
 # We do not use load_prompt and load_prompt_from_config in this project.
-CVE-2026-34070 exp:2026-05-31
+CVE-2026-34070 exp:2027-01-01

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 ARGS ?=
 POETRY ?= poetry
+POETRY_PYTHON ?= python
 
-.PHONY: all install build clean lint format test help
+# Any non-empty CI value (even 'false' or '0') means that CI is enabled
+CI ?=
+
+.PHONY: all init_env install build clean lint format test help
 
 all: build
 
+init_env:
+	$(if $(CI),,$(POETRY) env use $(POETRY_PYTHON))
 
-install:
+install: init_env
 	$(POETRY) install --all-extras
 
 build: install

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,11 @@
+import os
+
 import nox
 
 nox.options.sessions = ("lint", "test")
 nox.options.reuse_existing_virtualenvs = True
+if os.environ.get("CI"):
+    nox.options.default_venv_backend = "none"
 
 LOCATIONS = ("src", "tests", "noxfile.py")
 PYTHON_VERSIONS = ["3.11", "3.12"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,11 +1,7 @@
-import os
-
 import nox
 
 nox.options.sessions = ("lint", "test")
 nox.options.reuse_existing_virtualenvs = True
-if os.environ.get("CI"):
-    nox.options.default_venv_backend = "none"
 
 LOCATIONS = ("src", "tests", "noxfile.py")
 PYTHON_VERSIONS = ["3.11", "3.12"]
@@ -38,13 +34,7 @@ def test(session: nox.Session, numpy: str, langchain_core: str):
     else:
         args = session.posargs
     session.run("poetry", "sync", external=True)
-    session.run(
-        "pip",
-        "install",
-        f"langchain-core=={langchain_core}",
-        f"numpy=={numpy}",
-        external=True,
-    )
+    session.install(f"langchain-core=={langchain_core}", f"numpy=={numpy}")
     session.run("pytest", *args)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,13 @@ def test(session: nox.Session, numpy: str, langchain_core: str):
     else:
         args = session.posargs
     session.run("poetry", "sync", external=True)
-    session.install(f"langchain-core=={langchain_core}", f"numpy=={numpy}")
+    session.run(
+        "pip",
+        "install",
+        f"langchain-core=={langchain_core}",
+        f"numpy=={numpy}",
+        external=True,
+    )
     session.run("pytest", *args)
 
 


### PR DESCRIPTION
CI speed-up:
- instruct **nox** to reuse the existing venv (created by **poetry**) instead of building a fresh one per session.

For local execution everything stays the same

Additionally, prolong exception for `langchain-core` CVE (in old version) and add license exception for `websockets` (BSD 3-Clause is fine)